### PR TITLE
Fix InvalidTimestamp in loggly notification section by reducing the number of fraction of a second digits to six

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -2,7 +2,6 @@ package logrusly
 
 import (
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/segmentio/go-loggly"
@@ -14,6 +13,13 @@ type LogglyHook struct {
 	host   string
 	levels []logrus.Level
 }
+
+const (
+
+	// RFC3339Micro represents microseconds/seconds fraction (6 digits)
+	// that can be automatically parse by Loggly
+	RFC3339Micro = "2006-01-02T15:04:05.999999Z07:00"
+)
 
 // NewLogglyHook creates a Loogly hook to be added to an instance of logger.
 func NewLogglyHook(token string, host string, level logrus.Level, tags ...string) *LogglyHook {
@@ -76,7 +82,7 @@ func (hook *LogglyHook) Fire(entry *logrus.Entry) error {
 	level := entry.Level.String()
 
 	logglyMessage := loggly.Message{
-		"timestamp": entry.Time.UTC().Format(time.RFC3339Nano),
+		"timestamp": entry.Time.UTC().Format(RFC3339Micro),
 		"level":     strings.ToUpper(level),
 		"message":   entry.Message,
 		"host":      hook.host,


### PR DESCRIPTION
**Before**
![loggly-fix-01](https://cloud.githubusercontent.com/assets/1134763/15168178/3a5a8330-1759-11e6-8491-05cd3f1a8db7.png)

**After**
![loggly-fix-02](https://cloud.githubusercontent.com/assets/1134763/15168181/3dbb041e-1759-11e6-9791-aaa405e25613.png)
