### PR TITLE
logrus now lives under 'sirupsen' (lowercase s)

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -3,8 +3,8 @@ package logrusly
 import (
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/segmentio/go-loggly"
+	"github.com/sirupsen/logrus"
 )
 
 // LogglyHook to send logs to the Loggly service.


### PR DESCRIPTION
See https://github.com/sirupsen/logrus/issues/451